### PR TITLE
numpy version pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 scipy >= 0.12.1
-numpy >= 1.16
+numpy == 1.26.4
 astropy >= 1.1.1
 configparser
 tqdm >= 4.0


### PR DESCRIPTION
pinning numpy version because of new numpy version released on june 16 (https://stackoverflow.com/questions/78634235/numpy-dtype-size-changed-may-indicate-binary-incompatibility-expected-96-from)